### PR TITLE
Fix code generating random file name in the temp folder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,12 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as os from "os";
+import * as path from "path";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("vscode-emojicode.runProgram", async () => {
-      const dir = await fs.promises.mkdtemp(os.tmpdir());
+      const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(),"emojic-"));
       const file = vscode.window.activeTextEditor?.document.fileName;
 
       await vscode.window.activeTextEditor?.document.save();


### PR DESCRIPTION
Before the `os.tmpdir()` returned `/tmp` and feeding this to `mkdtemp()`
resulted in `/tmp<random_chars>` without the path delimiter.

![image](https://user-images.githubusercontent.com/1296768/176010751-88ca3258-eafe-48da-ad42-820829cd21ed.png)

Using `path.join` with a prefix ensures that correct tmp path is
generated (`/tmp/emojic-<random_chars>`) and temp file can be created.